### PR TITLE
Add support to customizable table name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/lib
+/node_modules

--- a/src/Mysql/index.ts
+++ b/src/Mysql/index.ts
@@ -14,10 +14,13 @@ import { MySQLConfig, sqlData, sqlConnection, AuthenticationCreds } from '../Typ
  */
 
 let conn: sqlConnection
+const DEFAULT_TABLE_NAME = 'auth';
 
 async function connection(config: MySQLConfig, force: true | false = false){
 	const ended = !!conn?.connection?._closing
 	const newConnection = conn === undefined
+
+	const tableName = config?.tableName || DEFAULT_TABLE_NAME;
 
 	if (newConnection || ended || force){
 		conn = await createConnection({
@@ -31,7 +34,7 @@ async function connection(config: MySQLConfig, force: true | false = false){
 		})
 
 		if (newConnection) {
-			await conn.execute('CREATE TABLE IF NOT EXISTS `auth` (`session` varchar(50) NOT NULL, `id` varchar(70) NOT NULL, `value` json DEFAULT NULL, UNIQUE KEY `idxunique` (`session`,`id`), KEY `idxsession` (`session`), KEY `idxid` (`id`)) ENGINE=MyISAM;')
+			await conn.execute('CREATE TABLE IF NOT EXISTS `' + tableName + '` (`session` varchar(50) NOT NULL, `id` varchar(70) NOT NULL, `value` json DEFAULT NULL, UNIQUE KEY `idxunique` (`session`,`id`), KEY `idxsession` (`session`), KEY `idxid` (`id`)) ENGINE=MyISAM;')
 
 			setInterval(async () => {
 				if (!conn?.connection?._closing){
@@ -53,6 +56,8 @@ export const useMySQLAuthState = async(config: MySQLConfig): Promise<{ state: ob
 
 	const session = config?.session
 
+	const tableName = config?.tableName || DEFAULT_TABLE_NAME;
+
 	const query = async (sql: string, values: Array<string>) => {
 		await sqlConn.ping().catch(async () => {
 			sqlConn = await connection(config, true)
@@ -62,7 +67,7 @@ export const useMySQLAuthState = async(config: MySQLConfig): Promise<{ state: ob
 	}
 
 	const readData = async (id: string) => {
-		const data = await query(`SELECT value FROM auth WHERE id = ? AND session = ?`, [id, session])
+		const data = await query(`SELECT value FROM ${tableName} WHERE id = ? AND session = ?`, [id, session])
 		if(!data[0]?.value){
 			return null
 		}
@@ -73,15 +78,15 @@ export const useMySQLAuthState = async(config: MySQLConfig): Promise<{ state: ob
 
 	const writeData = async (id: string, value: object) => {
 		const valueFixed = JSON.stringify(value, BufferJSON.replacer)
-		await query(`INSERT INTO auth (value, id, session) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE value = ?`, [valueFixed, id, session, valueFixed])
+		await query(`INSERT INTO ${tableName} (value, id, session) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE value = ?`, [valueFixed, id, session, valueFixed])
 	}
 
 	const removeData = async (id: string) => {
-		await query(`DELETE FROM auth WHERE id = ? AND session = ?`, [id, session])
+		await query(`DELETE FROM ${tableName} WHERE id = ? AND session = ?`, [id, session])
 	}
 
 	const removeAll = async () => {
-		await query(`DELETE FROM auth WHERE session = ?`, [session])
+		await query(`DELETE FROM ${tableName} WHERE session = ?`, [session])
 	}
 
 	const creds: AuthenticationCreds = await readData('creds') || initAuthCreds()

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -23,6 +23,7 @@ export type MySQLConfig = {
 	password: string
 	database: string
 	ssl?: any | undefined
+	tableName?: string | undefined
 }
 
 export type valueReplacer = {


### PR DESCRIPTION
This PR adds a configuration parameter, `tableName` , which enable the customization of the table name, while leaving `auth` as default choice.