### PR TITLE
Fixed docs in stable version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm i github:bobslavtriev/mysql-baileys
 ```
 Stable Version:
 ```
-npm i bobslavtriev/mysql-baileys
+npm i mysql-baileys
 ```
 
 ### 3. Import code


### PR DESCRIPTION
update the command for stable version install.

This is necessary because when I do `npm i bobslavtriev/mysql-baileys` 
it installs this `"mysql-baileys": "github:bobslavtriev/mysql-baileys"`