### PR TITLE
Fix: match AuthenticationCreds type with baileys type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "bobslavtriev",
 	"name": "mysql-baileys",
-	"version": "1.5.4",
+	"version": "1.5.5",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
 	"description": "Implementation of MySQL in Baileys.",

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -189,7 +189,9 @@ export type AuthenticationCreds = SignalCreds & {
 	processedHistoryMessages: Pick<any, 'key' | 'messageTimestamp'>[]
 	accountSyncCounter: number
 	accountSettings: AccountSettings
-	pairingCode?: string
-	lastPropHash?: string
-	routingInfo?: Buffer
+	registered: boolean
+	pairingCode: string | undefined
+	lastPropHash: string | undefined
+	routingInfo: Buffer | undefined
+	additionalData?: any | undefined
 }


### PR DESCRIPTION
This PR fixes a type problem between the type `AuthenticationCreds` in this code, and the type in baileys.

<img width="820" height="343" alt="image" src="https://github.com/user-attachments/assets/2ab7aefe-be21-429b-bea1-91f7df68fe0c" />
